### PR TITLE
Return the result of create_tag to caller

### DIFF
--- a/lib/GitLab/API/v3.pm
+++ b/lib/GitLab/API/v3.pm
@@ -1201,8 +1201,7 @@ sub create_tag {
     my $params = pop;
     my $path = sprintf('/projects/%s/repository/tags', (map { uri_escape($_) } @_));
     $log->infof( 'Making %s request against %s with params %s.', 'POST', $path, $params );
-    $self->post( $path, ( defined($params) ? $params : () ) );
-    return;
+    return $self->post( $path, ( defined($params) ? $params : () ) );
 }
 
 =head2 tree


### PR DESCRIPTION
Hello!

I was rewriting some Rex code today, and I freaked out a little when the return value of $client->create_tag was undef. After experimenting a little, I figured out that an error would've triggered an exception, and the return data for successfully creating a new tag and finding an existing tag are the same... but I like giving the data I have to the caller, unless there's a good reason not to.

Cheers!