### PR TITLE
Add retry parameter for retrying responses in 500 block

### DIFF
--- a/author/generate.pl
+++ b/author/generate.pl
@@ -100,8 +100,6 @@ foreach my $section_name (keys %$section_pack) {
         $sprintf_path =~ s{:[^/]+}{%s}g;
         print "    my \$path = sprintf('$sprintf_path', (map { uri_escape(\$_) } \@_));\n";
 
-        print "    \$log->infof( 'Making %s request against %s.', '$method', \$path );\n";
-
         my $method_sub = lc( $method );
         print '    ';
         print 'return ' if $return;

--- a/author/header.pm
+++ b/author/header.pm
@@ -160,8 +160,9 @@ sub _build_rest_client {
     $log->debugf( 'Creating a %s instance pointed at %s.', $class, $url );
 
     my $rest = $class->new(
-        server => $url,
-        type   => 'application/json',
+        server  => $url,
+        type    => 'application/json',
+        retries => $self->retries,
     );
 
     $rest->set_persistent_header(
@@ -170,6 +171,20 @@ sub _build_rest_client {
 
     return $rest;
 }
+
+=head2 retries
+
+The number of times the request should be retried in case it does not succeed.
+Defaults to 0, meaning that a failed request will not be retried.
+
+=cut
+
+has retries => (
+    is      => 'ro',
+    isa     => Int,
+    lazy    => 1,
+    default => 0,
+);
 
 =head1 UTILITY METHODS
 

--- a/bin/gitlab-api-v3
+++ b/bin/gitlab-api-v3
@@ -20,6 +20,7 @@ GetOptions(
     'token=s'  => \my $token,
     'all'      => \my $all,
     'format=s' => \my $format,
+    'retry=i'  => \my $retries,
 
     'help'     => \my $help,
     'verbose'  => \my $verbose,
@@ -85,8 +86,9 @@ my $method = shift( @args );
 
 try {
     my $api = GitLab::API::v3->new(
-        url   => $url,
-        token => $token,
+        url     => $url,
+        token   => $token,
+        retries => $retries,
     );
 
     if ($all) {

--- a/lib/GitLab/API/v3.pm
+++ b/lib/GitLab/API/v3.pm
@@ -160,8 +160,9 @@ sub _build_rest_client {
     $log->debugf( 'Creating a %s instance pointed at %s.', $class, $url );
 
     my $rest = $class->new(
-        server => $url,
-        type   => 'application/json',
+        server  => $url,
+        type    => 'application/json',
+        retries => $self->retries,
     );
 
     $rest->set_persistent_header(
@@ -170,6 +171,20 @@ sub _build_rest_client {
 
     return $rest;
 }
+
+=head2 retries
+
+The number of times the request should be retried in case it does not succeed.
+Defaults to 0, meaning that a failed request will not be retried.
+
+=cut
+
+has retries => (
+    is      => 'ro',
+    isa     => Int,
+    lazy    => 1,
+    default => 0,
+);
 
 =head1 UTILITY METHODS
 
@@ -263,7 +278,6 @@ sub issue_award_emojis {
     croak 'The #1 argument ($id) to issue_award_emojis must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($issue_id) to issue_award_emojis must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/issues/%s/award_emoji', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -284,7 +298,6 @@ sub merge_request_award_emojis {
     croak 'The #1 argument ($id) to merge_request_award_emojis must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($merge_request_id) to merge_request_award_emojis must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/merge_requests/%s/award_emoji', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -307,7 +320,6 @@ sub issue_award_emoji {
     croak 'The #2 argument ($issue_id) to issue_award_emoji must be a scalar' if ref($_[1]) or (!defined $_[1]);
     croak 'The #3 argument ($award_id) to issue_award_emoji must be a scalar' if ref($_[2]) or (!defined $_[2]);
     my $path = sprintf('/projects/%s/issues/%s/award_emoji/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -330,7 +342,6 @@ sub merge_request_award_emoji {
     croak 'The #2 argument ($merge_request_id) to merge_request_award_emoji must be a scalar' if ref($_[1]) or (!defined $_[1]);
     croak 'The #3 argument ($award_id) to merge_request_award_emoji must be a scalar' if ref($_[2]) or (!defined $_[2]);
     my $path = sprintf('/projects/%s/merge_requests/%s/award_emoji/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -354,7 +365,6 @@ sub create_issue_award_emoji {
     croak 'The last argument (\%params) to create_issue_award_emoji must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/issues/%s/award_emoji', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -378,7 +388,6 @@ sub create_merge_request_award_emoji {
     croak 'The last argument (\%params) to create_merge_request_award_emoji must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/merge_requests/%s/award_emoji', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -401,7 +410,6 @@ sub delete_issue_award_emoji {
     croak 'The #2 argument ($issue_id) to delete_issue_award_emoji must be a scalar' if ref($_[1]) or (!defined $_[1]);
     croak 'The #3 argument ($award_id) to delete_issue_award_emoji must be a scalar' if ref($_[2]) or (!defined $_[2]);
     my $path = sprintf('/projects/%s/issues/%s/award_emoji/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     return $self->delete( $path );
 }
 
@@ -424,7 +432,6 @@ sub delete_merge_request_award_emoji {
     croak 'The #2 argument ($merge_request_id) to delete_merge_request_award_emoji must be a scalar' if ref($_[1]) or (!defined $_[1]);
     croak 'The #3 argument ($award_id) to delete_merge_request_award_emoji must be a scalar' if ref($_[2]) or (!defined $_[2]);
     my $path = sprintf('/projects/%s/merge_requests/%s/award_emoji/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     return $self->delete( $path );
 }
 
@@ -447,7 +454,6 @@ sub issue_note_award_emojis {
     croak 'The #2 argument ($issue_id) to issue_note_award_emojis must be a scalar' if ref($_[1]) or (!defined $_[1]);
     croak 'The #3 argument ($note_id) to issue_note_award_emojis must be a scalar' if ref($_[2]) or (!defined $_[2]);
     my $path = sprintf('/projects/%s/issues/%s/notes/%s/award_emoji', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -472,7 +478,6 @@ sub issue_note_award_emoji {
     croak 'The #3 argument ($note_id) to issue_note_award_emoji must be a scalar' if ref($_[2]) or (!defined $_[2]);
     croak 'The #4 argument ($award_id) to issue_note_award_emoji must be a scalar' if ref($_[3]) or (!defined $_[3]);
     my $path = sprintf('/projects/%s/issues/%s/notes/%s/award_emoji/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -498,7 +503,6 @@ sub create_issue_note_award_emoji {
     croak 'The last argument (\%params) to create_issue_note_award_emoji must be a hash ref' if defined($_[3]) and ref($_[3]) ne 'HASH';
     my $params = (@_ == 4) ? pop() : undef;
     my $path = sprintf('/projects/%s/issues/%s/notes/%s/award_emoji', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -523,7 +527,6 @@ sub delete_issue_note_award_emoji {
     croak 'The #3 argument ($note_id) to delete_issue_note_award_emoji must be a scalar' if ref($_[2]) or (!defined $_[2]);
     croak 'The #4 argument ($award_id) to delete_issue_note_award_emoji must be a scalar' if ref($_[3]) or (!defined $_[3]);
     my $path = sprintf('/projects/%s/issues/%s/notes/%s/award_emoji/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     return $self->delete( $path );
 }
 
@@ -546,7 +549,6 @@ sub merge_request_note_award_emojis {
     croak 'The #2 argument ($merge_request_id) to merge_request_note_award_emojis must be a scalar' if ref($_[1]) or (!defined $_[1]);
     croak 'The #3 argument ($note_id) to merge_request_note_award_emojis must be a scalar' if ref($_[2]) or (!defined $_[2]);
     my $path = sprintf('/projects/%s/merge_requests/%s/notes/%s/award_emoji', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -571,7 +573,6 @@ sub merge_request_note_award_emoji {
     croak 'The #3 argument ($note_id) to merge_request_note_award_emoji must be a scalar' if ref($_[2]) or (!defined $_[2]);
     croak 'The #4 argument ($award_id) to merge_request_note_award_emoji must be a scalar' if ref($_[3]) or (!defined $_[3]);
     my $path = sprintf('/projects/%s/merge_requests/%s/notes/%s/award_emoji/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -597,7 +598,6 @@ sub create_merge_request_note_award_emoji {
     croak 'The last argument (\%params) to create_merge_request_note_award_emoji must be a hash ref' if defined($_[3]) and ref($_[3]) ne 'HASH';
     my $params = (@_ == 4) ? pop() : undef;
     my $path = sprintf('/projects/%s/merge_requests/%s/notes/%s/award_emoji', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -622,7 +622,6 @@ sub delete_merge_request_note_award_emoji {
     croak 'The #3 argument ($note_id) to delete_merge_request_note_award_emoji must be a scalar' if ref($_[2]) or (!defined $_[2]);
     croak 'The #4 argument ($award_id) to delete_merge_request_note_award_emoji must be a scalar' if ref($_[3]) or (!defined $_[3]);
     my $path = sprintf('/projects/%s/merge_requests/%s/notes/%s/award_emoji/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     return $self->delete( $path );
 }
 
@@ -645,7 +644,6 @@ sub branches {
     croak 'branches must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($project_id) to branches must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/projects/%s/repository/branches', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -666,7 +664,6 @@ sub branch {
     croak 'The #1 argument ($project_id) to branch must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($branch_name) to branch must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/repository/branches/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -690,7 +687,6 @@ sub protect_branch {
     croak 'The last argument (\%params) to protect_branch must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/branches/%s/protect', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     $self->put( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -712,7 +708,6 @@ sub unprotect_branch {
     croak 'The #1 argument ($project_id) to unprotect_branch must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($branch_name) to unprotect_branch must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/repository/branches/%s/unprotect', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     $self->put( $path );
     return;
 }
@@ -735,7 +730,6 @@ sub create_branch {
     croak 'The last argument (\%params) to create_branch must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/branches', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -756,7 +750,6 @@ sub delete_branch {
     croak 'The #1 argument ($project_id) to delete_branch must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($branch_name) to delete_branch must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/repository/branches/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path );
     return;
 }
@@ -783,7 +776,6 @@ sub builds {
     croak 'The last argument (\%params) to builds must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/builds', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -807,7 +799,6 @@ sub commit_builds {
     croak 'The last argument (\%params) to commit_builds must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/commits/%s/builds', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -828,7 +819,6 @@ sub build {
     croak 'The #1 argument ($id) to build must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($build_id) to build must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/builds/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -849,7 +839,6 @@ sub build_artifacts {
     croak 'The #1 argument ($id) to build_artifacts must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($build_id) to build_artifacts must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/builds/%s/artifacts', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -870,7 +859,6 @@ sub build_trace {
     croak 'The #1 argument ($id) to build_trace must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($build_id) to build_trace must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/builds/%s/trace', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -891,7 +879,6 @@ sub cancel_build {
     croak 'The #1 argument ($id) to cancel_build must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($build_id) to cancel_build must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/builds/%s/cancel', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path );
 }
 
@@ -912,7 +899,6 @@ sub retry_build {
     croak 'The #1 argument ($id) to retry_build must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($build_id) to retry_build must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/builds/%s/retry', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path );
 }
 
@@ -933,7 +919,6 @@ sub erase_build {
     croak 'The #1 argument ($id) to erase_build must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($build_id) to erase_build must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/builds/%s/erase', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path );
 }
 
@@ -954,7 +939,6 @@ sub keep_build_artifacts {
     croak 'The #1 argument ($id) to keep_build_artifacts must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($build_id) to keep_build_artifacts must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/builds/%s/artifacts/keep', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path );
 }
 
@@ -977,7 +961,6 @@ sub triggers {
     croak 'triggers must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($id) to triggers must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/projects/%s/triggers', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -998,7 +981,6 @@ sub trigger {
     croak 'The #1 argument ($id) to trigger must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($token) to trigger must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/triggers/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -1017,7 +999,6 @@ sub create_trigger {
     croak 'create_trigger must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($id) to create_trigger must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/projects/%s/triggers', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path );
 }
 
@@ -1038,7 +1019,6 @@ sub delete_trigger {
     croak 'The #1 argument ($id) to delete_trigger must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($token) to delete_trigger must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/triggers/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     return $self->delete( $path );
 }
 
@@ -1061,7 +1041,6 @@ sub variables {
     croak 'variables must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($id) to variables must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/projects/%s/variables', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -1082,7 +1061,6 @@ sub variable {
     croak 'The #1 argument ($id) to variable must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($key) to variable must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/variables/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -1104,7 +1082,6 @@ sub create_variable {
     croak 'The last argument (\%params) to create_variable must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/variables', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -1128,7 +1105,6 @@ sub update_variable {
     croak 'The last argument (\%params) to update_variable must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/variables/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     return $self->put( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -1149,7 +1125,6 @@ sub delete_variable {
     croak 'The #1 argument ($id) to delete_variable must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($key) to delete_variable must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/variables/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     return $self->delete( $path );
 }
 
@@ -1175,7 +1150,6 @@ sub commits {
     croak 'The last argument (\%params) to commits must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/commits', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -1196,7 +1170,6 @@ sub commit {
     croak 'The #1 argument ($project_id) to commit must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($commit_sha) to commit must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/repository/commits/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -1217,7 +1190,6 @@ sub commit_diff {
     croak 'The #1 argument ($project_id) to commit_diff must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($commit_sha) to commit_diff must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/repository/commits/%s/diff', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -1238,7 +1210,6 @@ sub commit_comments {
     croak 'The #1 argument ($project_id) to commit_comments must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($commit_sha) to commit_comments must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/repository/commits/%s/comments', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -1262,7 +1233,6 @@ sub add_commit_comment {
     croak 'The last argument (\%params) to add_commit_comment must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/commits/%s/comments', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -1286,7 +1256,6 @@ sub deploy_keys {
     croak 'deploy_keys must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($project_id) to deploy_keys must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/projects/%s/keys', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -1307,7 +1276,6 @@ sub deploy_key {
     croak 'The #1 argument ($project_id) to deploy_key must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($key_id) to deploy_key must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/keys/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -1329,7 +1297,6 @@ sub create_deploy_key {
     croak 'The last argument (\%params) to create_deploy_key must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/keys', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -1351,7 +1318,6 @@ sub delete_deploy_key {
     croak 'The #1 argument ($project_id) to delete_deploy_key must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($key_id) to delete_deploy_key must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/keys/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path );
     return;
 }
@@ -1372,7 +1338,6 @@ sub groups {
     my $self = shift;
     croak "The groups method does not take any arguments" if @_;
     my $path = sprintf('/groups', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -1391,7 +1356,6 @@ sub group {
     croak 'group must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($group_id) to group must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/groups/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -1411,7 +1375,6 @@ sub create_group {
     croak 'The last argument (\%params) to create_group must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/groups', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -1433,7 +1396,6 @@ sub transfer_project {
     croak 'The #1 argument ($group_id) to transfer_project must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($project_id) to transfer_project must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/groups/%s/projects/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path );
     return;
 }
@@ -1453,7 +1415,6 @@ sub delete_group {
     croak 'delete_group must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($group_id) to delete_group must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/groups/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path );
     return;
 }
@@ -1474,7 +1435,6 @@ sub search_groups {
     croak 'The last argument (\%params) to search_groups must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/groups', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -1493,7 +1453,6 @@ sub group_members {
     croak 'group_members must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($group_id) to group_members must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/groups/%s/members', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -1515,7 +1474,6 @@ sub group_projects {
     croak 'The last argument (\%params) to group_projects must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/groups/%s/projects', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -1537,7 +1495,6 @@ sub add_group_member {
     croak 'The last argument (\%params) to add_group_member must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/groups/%s/members', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -1562,7 +1519,6 @@ sub edit_group_member {
     croak 'The last argument (\%params) to edit_group_member must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/groups/%s/members/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     $self->put( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -1584,7 +1540,6 @@ sub remove_group_member {
     croak 'The #1 argument ($group_id) to remove_group_member must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($user_id) to remove_group_member must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/groups/%s/members/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path );
     return;
 }
@@ -1609,7 +1564,6 @@ sub all_issues {
     croak 'The last argument (\%params) to all_issues must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/issues', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -1631,7 +1585,6 @@ sub issues {
     croak 'The last argument (\%params) to issues must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/issues', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -1652,7 +1605,6 @@ sub issue {
     croak 'The #1 argument ($project_id) to issue must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($issue_id) to issue must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/issues/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -1674,7 +1626,6 @@ sub create_issue {
     croak 'The last argument (\%params) to create_issue must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/issues', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -1698,7 +1649,6 @@ sub edit_issue {
     croak 'The last argument (\%params) to edit_issue must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/issues/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     return $self->put( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -1721,7 +1671,6 @@ sub key {
     croak 'key must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($key_id) to key must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/keys/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -1744,7 +1693,6 @@ sub labels {
     croak 'labels must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($project_id) to labels must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/projects/%s/labels', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -1766,7 +1714,6 @@ sub create_label {
     croak 'The last argument (\%params) to create_label must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/labels', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -1788,7 +1735,6 @@ sub delete_label {
     croak 'The last argument (\%params) to delete_label must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/labels', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -1811,7 +1757,6 @@ sub edit_label {
     croak 'The last argument (\%params) to edit_label must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/labels', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     return $self->put( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -1837,7 +1782,6 @@ sub merge_requests {
     croak 'The last argument (\%params) to merge_requests must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/merge_requests', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -1858,7 +1802,6 @@ sub merge_request {
     croak 'The #1 argument ($project_id) to merge_request must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($merge_request_id) to merge_request must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/merge_request/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -1880,7 +1823,6 @@ sub create_merge_request {
     croak 'The last argument (\%params) to create_merge_request must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/merge_requests', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -1904,7 +1846,6 @@ sub edit_merge_request {
     croak 'The last argument (\%params) to edit_merge_request must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/merge_requests/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     return $self->put( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -1928,7 +1869,6 @@ sub accept_merge_request {
     croak 'The last argument (\%params) to accept_merge_request must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/merge_requests/%s/merge', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     $self->put( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -1953,7 +1893,6 @@ sub add_merge_request_comment {
     croak 'The last argument (\%params) to add_merge_request_comment must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/merge_requests/%s/comments', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -1975,7 +1914,6 @@ sub merge_request_comments {
     croak 'The #1 argument ($project_id) to merge_request_comments must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($merge_request_id) to merge_request_comments must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/merge_requests/%s/comments', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -2001,7 +1939,6 @@ sub milestones {
     croak 'The last argument (\%params) to milestones must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/milestones', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -2022,7 +1959,6 @@ sub milestone {
     croak 'The #1 argument ($project_id) to milestone must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($milestone_id) to milestone must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/milestones/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -2044,7 +1980,6 @@ sub create_milestone {
     croak 'The last argument (\%params) to create_milestone must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/milestones', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -2069,7 +2004,6 @@ sub edit_milestone {
     croak 'The last argument (\%params) to edit_milestone must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/milestones/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     $self->put( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -2091,7 +2025,6 @@ sub milestone_issues {
     croak 'The #1 argument ($project_id) to milestone_issues must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($milestone_id) to milestone_issues must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/milestones/%s/issues', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -2115,7 +2048,6 @@ sub licenses {
     croak 'The last argument (\%params) to licenses must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/licenses', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -2137,7 +2069,6 @@ sub license {
     croak 'The last argument (\%params) to license must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/licenses/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -2161,7 +2092,6 @@ sub namespaces {
     croak 'The last argument (\%params) to namespaces must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/namespaces', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -2188,7 +2118,6 @@ sub notes {
     croak 'The #2 argument ($thing_type) to notes must be a scalar' if ref($_[1]) or (!defined $_[1]);
     croak 'The #3 argument ($thing_id) to notes must be a scalar' if ref($_[2]) or (!defined $_[2]);
     my $path = sprintf('/projects/%s/%s/%s/notes', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -2213,7 +2142,6 @@ sub note {
     croak 'The #3 argument ($thing_id) to note must be a scalar' if ref($_[2]) or (!defined $_[2]);
     croak 'The #4 argument ($note_id) to note must be a scalar' if ref($_[3]) or (!defined $_[3]);
     my $path = sprintf('/projects/%s/%s/%s/notes/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -2239,7 +2167,6 @@ sub create_note {
     croak 'The last argument (\%params) to create_note must be a hash ref' if defined($_[3]) and ref($_[3]) ne 'HASH';
     my $params = (@_ == 4) ? pop() : undef;
     my $path = sprintf('/projects/%s/%s/%s/notes', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -2268,7 +2195,6 @@ sub edit_note {
     croak 'The last argument (\%params) to edit_note must be a hash ref' if defined($_[4]) and ref($_[4]) ne 'HASH';
     my $params = (@_ == 5) ? pop() : undef;
     my $path = sprintf('/projects/%s/%s/%s/notes/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     $self->put( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -2293,7 +2219,6 @@ sub projects {
     croak 'The last argument (\%params) to projects must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/projects', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -2313,7 +2238,6 @@ sub owned_projects {
     croak 'The last argument (\%params) to owned_projects must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/projects/owned', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -2333,7 +2257,6 @@ sub all_projects {
     croak 'The last argument (\%params) to all_projects must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/projects/all', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -2352,7 +2275,6 @@ sub project {
     croak 'project must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($project_id) to project must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/projects/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -2371,7 +2293,6 @@ sub project_events {
     croak 'project_events must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($project_id) to project_events must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/projects/%s/events', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -2391,7 +2312,6 @@ sub create_project {
     croak 'The last argument (\%params) to create_project must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/projects', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -2413,7 +2333,6 @@ sub create_project_for_user {
     croak 'The last argument (\%params) to create_project_for_user must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/user/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -2436,7 +2355,6 @@ sub edit_project {
     croak 'The last argument (\%params) to edit_project must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     return $self->put( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -2455,7 +2373,6 @@ sub fork_project {
     croak 'fork_project must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($project_id) to fork_project must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/pojects/fork/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path );
     return;
 }
@@ -2475,7 +2392,6 @@ sub delete_project {
     croak 'delete_project must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($project_id) to delete_project must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/projects/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path );
     return;
 }
@@ -2498,7 +2414,6 @@ sub project_members {
     croak 'The last argument (\%params) to project_members must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/members', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -2519,7 +2434,6 @@ sub project_member {
     croak 'The #1 argument ($project_id) to project_member must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($user_id) to project_member must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/project/%s/members/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -2541,7 +2455,6 @@ sub add_project_member {
     croak 'The last argument (\%params) to add_project_member must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/members', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -2566,7 +2479,6 @@ sub edit_project_member {
     croak 'The last argument (\%params) to edit_project_member must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/members/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     $self->put( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -2588,7 +2500,6 @@ sub remove_project_member {
     croak 'The #1 argument ($project_id) to remove_project_member must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($user_id) to remove_project_member must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/members/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path );
     return;
 }
@@ -2611,7 +2522,6 @@ sub share_project_with_group {
     croak 'The last argument (\%params) to share_project_with_group must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/share', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -2633,7 +2543,6 @@ sub delete_shared_project_link_within_group {
     croak 'The #1 argument ($id) to delete_shared_project_link_within_group must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($group_id) to delete_shared_project_link_within_group must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/share/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path );
     return;
 }
@@ -2653,7 +2562,6 @@ sub project_hooks {
     croak 'project_hooks must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($project_id) to project_hooks must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/projects/%s/hooks', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -2674,7 +2582,6 @@ sub project_hook {
     croak 'The #1 argument ($project_id) to project_hook must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($hook_id) to project_hook must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/project/%s/hooks/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -2696,7 +2603,6 @@ sub create_project_hook {
     croak 'The last argument (\%params) to create_project_hook must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/hooks', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -2721,7 +2627,6 @@ sub edit_project_hook {
     croak 'The last argument (\%params) to edit_project_hook must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/hooks/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     $self->put( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -2743,7 +2648,6 @@ sub delete_project_hook {
     croak 'The #1 argument ($project_id) to delete_project_hook must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($hook_id) to delete_project_hook must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/hooks/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     return $self->delete( $path );
 }
 
@@ -2764,7 +2668,6 @@ sub set_project_fork {
     croak 'The #1 argument ($project_id) to set_project_fork must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($forked_from_id) to set_project_fork must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/fork/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path );
     return;
 }
@@ -2784,7 +2687,6 @@ sub clear_project_fork {
     croak 'clear_project_fork must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($project_id) to clear_project_fork must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/projects/%s/fork', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path );
     return;
 }
@@ -2807,7 +2709,6 @@ sub search_projects_by_name {
     croak 'The last argument (\%params) to search_projects_by_name must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/search/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -2830,7 +2731,6 @@ sub snippets {
     croak 'snippets must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($project_id) to snippets must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/projects/%s/snippets', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -2851,7 +2751,6 @@ sub snippet {
     croak 'The #1 argument ($project_id) to snippet must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($snippet_id) to snippet must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/snippets/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -2873,7 +2772,6 @@ sub create_snippet {
     croak 'The last argument (\%params) to create_snippet must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/snippets', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -2898,7 +2796,6 @@ sub edit_snippet {
     croak 'The last argument (\%params) to edit_snippet must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/snippets/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     $self->put( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -2920,7 +2817,6 @@ sub delete_snippet {
     croak 'The #1 argument ($project_id) to delete_snippet must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($snippet_id) to delete_snippet must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/snippets/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path );
     return;
 }
@@ -2942,7 +2838,6 @@ sub snippet_content {
     croak 'The #1 argument ($project_id) to snippet_content must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($snippet_id) to snippet_content must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/snippets/%s/raw', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -2968,7 +2863,6 @@ sub tree {
     croak 'The last argument (\%params) to tree must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/tree', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -2992,7 +2886,6 @@ sub blob {
     croak 'The last argument (\%params) to blob must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/blobs/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -3013,7 +2906,6 @@ sub raw_blob {
     croak 'The #1 argument ($project_id) to raw_blob must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($blob_sha) to raw_blob must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/repository/raw_blobs/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3035,7 +2927,6 @@ sub archive {
     croak 'The last argument (\%params) to archive must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/archive', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -3057,7 +2948,6 @@ sub compare {
     croak 'The last argument (\%params) to compare must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/compare', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -3076,7 +2966,6 @@ sub contributors {
     croak 'contributors must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($project_id) to contributors must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/projects/%s/repository/contributors', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3102,7 +2991,6 @@ sub file {
     croak 'The last argument (\%params) to file must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/files', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -3124,7 +3012,6 @@ sub create_file {
     croak 'The last argument (\%params) to create_file must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/files', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -3147,7 +3034,6 @@ sub edit_file {
     croak 'The last argument (\%params) to edit_file must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/files', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     $self->put( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -3170,7 +3056,6 @@ sub delete_file {
     croak 'The last argument (\%params) to delete_file must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/files', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -3195,7 +3080,6 @@ sub runners {
     croak 'The last argument (\%params) to runners must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/runners', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -3215,7 +3099,6 @@ sub all_runners {
     croak 'The last argument (\%params) to all_runners must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/runners/all', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -3234,7 +3117,6 @@ sub runner {
     croak 'runner must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($id) to runner must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/runners/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3256,7 +3138,6 @@ sub update_runner {
     croak 'The last argument (\%params) to update_runner must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/runners/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     return $self->put( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -3275,7 +3156,6 @@ sub delete_runner {
     croak 'delete_runner must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($id) to delete_runner must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/runners/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     return $self->delete( $path );
 }
 
@@ -3294,7 +3174,6 @@ sub project_runners {
     croak 'project_runners must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($id) to project_runners must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/projects/%s/runners', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3316,7 +3195,6 @@ sub enable_project_runner {
     croak 'The last argument (\%params) to enable_project_runner must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/runners', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -3337,7 +3215,6 @@ sub disable_project_runner {
     croak 'The #1 argument ($id) to disable_project_runner must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($runner_id) to disable_project_runner must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/runners/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     return $self->delete( $path );
 }
 
@@ -3365,7 +3242,6 @@ sub edit_project_service {
     croak 'The last argument (\%params) to edit_project_service must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/services/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     $self->put( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -3387,7 +3263,6 @@ sub delete_project_service {
     croak 'The #1 argument ($project_id) to delete_project_service must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($service_name) to delete_project_service must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/services/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path );
     return;
 }
@@ -3412,7 +3287,6 @@ sub session {
     croak 'The last argument (\%params) to session must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/session', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -3432,7 +3306,6 @@ sub settings {
     my $self = shift;
     croak "The settings method does not take any arguments" if @_;
     my $path = sprintf('/application/settings', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3452,7 +3325,6 @@ sub update_settings {
     croak 'The last argument (\%params) to update_settings must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/application/settings', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     return $self->put( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -3472,7 +3344,6 @@ sub queue_metrics {
     my $self = shift;
     croak "The queue_metrics method does not take any arguments" if @_;
     my $path = sprintf('/sidekiq/queue_metrics', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3488,7 +3359,6 @@ sub process_metrics {
     my $self = shift;
     croak "The process_metrics method does not take any arguments" if @_;
     my $path = sprintf('/sidekiq/process_metrics', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3504,7 +3374,6 @@ sub job_stats {
     my $self = shift;
     croak "The job_stats method does not take any arguments" if @_;
     my $path = sprintf('/sidekiq/job_stats', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3520,7 +3389,6 @@ sub compound_metrics {
     my $self = shift;
     croak "The compound_metrics method does not take any arguments" if @_;
     my $path = sprintf('/sidekiq/compound_metrics', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3540,7 +3408,6 @@ sub hooks {
     my $self = shift;
     croak "The hooks method does not take any arguments" if @_;
     my $path = sprintf('/hooks', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3560,7 +3427,6 @@ sub create_hook {
     croak 'The last argument (\%params) to create_hook must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/hooks', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -3580,7 +3446,6 @@ sub test_hook {
     croak 'test_hook must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($hook_id) to test_hook must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/hooks/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3599,7 +3464,6 @@ sub delete_hook {
     croak 'delete_hook must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($hook_id) to delete_hook must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/hooks/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path );
     return;
 }
@@ -3623,7 +3487,6 @@ sub tags {
     croak 'tags must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($project_id) to tags must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/projects/%s/repository/tags', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3644,7 +3507,6 @@ sub tag {
     croak 'The #1 argument ($project_id) to tag must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($tag_name) to tag must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/repository/tags/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3666,7 +3528,6 @@ sub create_tag {
     croak 'The last argument (\%params) to create_tag must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/tags', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     return $self->post( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -3687,7 +3548,6 @@ sub delete_tag {
     croak 'The #1 argument ($project_id) to delete_tag must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($tag_name) to delete_tag must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/projects/%s/repository/tags/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path );
     return;
 }
@@ -3712,7 +3572,6 @@ sub create_release {
     croak 'The last argument (\%params) to create_release must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/tags/%s/release', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -3737,7 +3596,6 @@ sub update_release {
     croak 'The last argument (\%params) to update_release must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
     my $params = (@_ == 3) ? pop() : undef;
     my $path = sprintf('/projects/%s/repository/tags/%s/release', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     $self->put( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -3762,7 +3620,6 @@ sub users {
     croak 'The last argument (\%params) to users must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/users', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path, ( defined($params) ? $params : () ) );
 }
 
@@ -3781,7 +3638,6 @@ sub user {
     croak 'user must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($user_id) to user must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/users/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3801,7 +3657,6 @@ sub create_user {
     croak 'The last argument (\%params) to create_user must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/users', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -3824,7 +3679,6 @@ sub edit_user {
     croak 'The last argument (\%params) to edit_user must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/users/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'PUT', $path );
     $self->put( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -3844,7 +3698,6 @@ sub delete_user {
     croak 'delete_user must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($user_id) to delete_user must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/users/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     return $self->delete( $path );
 }
 
@@ -3860,7 +3713,6 @@ sub current_user {
     my $self = shift;
     croak "The current_user method does not take any arguments" if @_;
     my $path = sprintf('/user', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3876,7 +3728,6 @@ sub current_user_ssh_keys {
     my $self = shift;
     croak "The current_user_ssh_keys method does not take any arguments" if @_;
     my $path = sprintf('/user/keys', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3895,7 +3746,6 @@ sub user_ssh_keys {
     croak 'user_ssh_keys must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($user_id) to user_ssh_keys must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/users/%s/keys', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3914,7 +3764,6 @@ sub user_ssh_key {
     croak 'user_ssh_key must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($key_id) to user_ssh_key must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/user/keys/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'GET', $path );
     return $self->get( $path );
 }
 
@@ -3934,7 +3783,6 @@ sub create_current_user_ssh_key {
     croak 'The last argument (\%params) to create_current_user_ssh_key must be a hash ref' if defined($_[0]) and ref($_[0]) ne 'HASH';
     my $params = (@_ == 1) ? pop() : undef;
     my $path = sprintf('/user/keys', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -3957,7 +3805,6 @@ sub create_user_ssh_key {
     croak 'The last argument (\%params) to create_user_ssh_key must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $path = sprintf('/users/%s/keys', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'POST', $path );
     $self->post( $path, ( defined($params) ? $params : () ) );
     return;
 }
@@ -3977,7 +3824,6 @@ sub delete_current_user_ssh_key {
     croak 'delete_current_user_ssh_key must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($key_id) to delete_current_user_ssh_key must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('/user/keys/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path );
     return;
 }
@@ -3999,7 +3845,6 @@ sub delete_user_ssh_key {
     croak 'The #1 argument ($user_id) to delete_user_ssh_key must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($key_id) to delete_user_ssh_key must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $path = sprintf('/users/%s/keys/%s', (map { uri_escape($_) } @_));
-    $log->infof( 'Making %s request against %s.', 'DELETE', $path );
     $self->delete( $path );
     return;
 }

--- a/lib/GitLab/API/v3/RESTClient.pm
+++ b/lib/GitLab/API/v3/RESTClient.pm
@@ -23,8 +23,17 @@ use Carp qw( confess );
 use Data::Dumper qw();
 
 use Moo;
+use Try::Tiny;
 use strictures 1;
 use namespace::clean;
+use Log::Any qw( $log );
+use Types::Standard qw( Int );
+
+has retries => (
+  is => 'ro',
+  isa => Int,
+  default => 0,
+);
 
 with 'Role::REST::Client';
 
@@ -34,7 +43,19 @@ foreach my $method (qw( post get head put delete options )) {
         my $self = shift;
         my $path = shift;
 
-        my $res = $self->$orig( "/$path", @_ );
+        my $res;
+        my $retry = $self->retries;
+        do {
+          $log->infof( 'Making %s request against %s', uc($method), $path );
+          $res = $self->$orig( "/$path", @_ );
+
+          if ($res->code =~ /^5/) {
+            $log->warn('Request failed. Retrying...') if $retry;
+          }
+          else {
+            $retry = 0;
+          }
+        } while --$retry >= 0;
 
         return undef if $res->code() eq '404' and $method eq 'get';
 


### PR DESCRIPTION
This patch adds a `retries` argument to both `GitLab::API::v3` and `GitLab::API::v3::RESTClient`, and introduces a retry loop in the latter class' request methods. This would handle cases like #8.

As it stands right now, the loop repeats whenever the response code is in the `500` block, but there might be room for improvement there, depending on what the response codes from GitLab are.

This also moves the debug message into the request methods, since I thought it would be good if that message was printed each time the request was sent.
