### PR TITLE
Use latest changes in Role::REST::Client to disable deserialisation

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires 'Moo' => 1.006000;
-requires 'Role::REST::Client' => 0.18;
+requires 'Role::REST::Client' => 0.20;
 requires 'Type::Tiny' => 1;
 requires 'strictures' => 0;
 requires 'namespace::clean' => 0;

--- a/lib/GitLab/API/v3/RESTClient.pm
+++ b/lib/GitLab/API/v3/RESTClient.pm
@@ -87,28 +87,6 @@ sub _dump_one_line {
     return $value;
 }
 
-around _call => sub {
-    my $orig = shift;
-    my $self = shift;
-
-    my $res = $self->$orig(@_);
-
-    # Disable serialization when response is not serial data
-    # Annoyingly, this cannot be done using the Role::REST::Client API
-    my $type = $res->response->headers->{'content-type'};
-    if ($type =~ qr{\b(?:json|xml|yaml|x-www-form-urlencoded)\b}) {
-        return $res;
-    }
-    else {
-      return Role::REST::Client::Response->new(
-          code     => $res->code,
-          response => $res->response,
-          data     => sub { $res->response->decoded_content },
-          (defined $res->error) ? ( error => $res->error ) : (),
-      );
-    }
-};
-
 1;
 __END__
 


### PR DESCRIPTION
The merger of [#37](https://github.com/kaare/Role-REST-Client/pull/37) in Role::REST::Client (which has been [pushed to CPAN as 0.20](https://metacpan.org/release/KAARE/Role-REST-Client-0.20)) makes the changes in #26 no longer necessary.

This patch reverts those changes and updates the required version of Role::REST::Client in `cpanfile`.

This depends on the heuristics used in Role::REST::Client to disable deserialization. A more robust solution would be to set the deserialiser (or lack thereof) in the request itself. But this is a per-method solution, so it is not implemented in this patch.

This has been tested to work with at least `blob` and `archive`, which were the problematic methods in #5 